### PR TITLE
Adding support to customize the authority value on FileProvider

### DIFF
--- a/filebrowser/src/main/AndroidManifest.xml
+++ b/filebrowser/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
         <activity android:name=".utils.Permissions" android:theme="@style/Theme.AppCompat.Translucent" />
         <provider
             android:name="android.support.v4.content.FileProvider"
-            android:authorities="com.aditya.filebrowser.provider"
+            android:authorities="@string/aditya_filebrowser_provider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/filebrowser/src/main/java/com/aditya/filebrowser/FileBrowser.java
+++ b/filebrowser/src/main/java/com/aditya/filebrowser/FileBrowser.java
@@ -216,7 +216,7 @@ public class FileBrowser extends AppCompatActivity implements OnFileChangedListe
                         MimeTypeMap mimeMap = MimeTypeMap.getSingleton();
                         Intent openFileIntent = new Intent(Intent.ACTION_VIEW);
                         String mimeType = mimeMap.getMimeTypeFromExtension(FilenameUtils.getExtension(f.getName()));
-                        Uri uri = FileProvider.getUriForFile(mContext,"com.aditya.filebrowser.provider", f);
+                        Uri uri = FileProvider.getUriForFile(mContext, mContext.getString(R.string.aditya_filebrowser_provider), f);
                         openFileIntent.setDataAndType(uri,mimeType);
                         openFileIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                         openFileIntent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);

--- a/filebrowser/src/main/res/values/strings.xml
+++ b/filebrowser/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">File Browser</string>
+    <string name="aditya_filebrowser_provider">com.aditya.filebrowser.provider</string>
     <string name="cut">Cut</string>
     <string name="refresh">Refresh</string>
     <string name="paste">Paste</string>


### PR DESCRIPTION
I am developing an Android application that has many flavors. The problem is that when I try to install two or more versions (with a different package), the second application is not installed due to problems with the "FileProvider authority" value defined directly in AndroidManifest.xml

The solution, define the authority value as a string resource that allows to be overwritten in any application.